### PR TITLE
Align path & track transportation classes with OMT

### DIFF
--- a/resources/process-openmaptiles.lua
+++ b/resources/process-openmaptiles.lua
@@ -133,8 +133,8 @@ majorRoadValues = Set { "motorway", "trunk", "primary" }
 mainRoadValues  = Set { "secondary", "motorway_link", "trunk_link", "primary_link", "secondary_link" }
 midRoadValues   = Set { "tertiary", "tertiary_link" }
 minorRoadValues = Set { "unclassified", "residential", "road", "living_street" }
-trackValues     = Set { "cycleway", "byway", "bridleway", "track" }
-pathValues      = Set { "footway", "path", "steps", "pedestrian" }
+trackValues     = Set { "track" }
+pathValues      = Set { "footway", "cycleway", "bridleway", "path", "steps", "pedestrian" }
 linkValues      = Set { "motorway_link", "trunk_link", "primary_link", "secondary_link", "tertiary_link" }
 constructionValues = Set { "primary", "secondary", "tertiary", "motorway", "service", "trunk", "track" }
 


### PR DESCRIPTION
OpenMapTiles classifies `cycleway` and `bridleway` as `path` not `track`. Additionally, AFAICT from taginfo, there exists zero use of `highway=byway`.  This PR updates the omt lua process to make the tiles closer to the OMT schema.